### PR TITLE
Update for recent ESPHome releases

### DIFF
--- a/esphome/esphome_smarttherm.yaml
+++ b/esphome/esphome_smarttherm.yaml
@@ -3,21 +3,6 @@
 substitutions:
   unit_name: "smarttherm"
 
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-  fast_connect: true
-  reboot_timeout: 0s
-
-  ap:
-    ssid: ${unit_name} Fallback Hotspot
-    password: !secret fallback_password
-
-captive_portal:
-
-ota:
-  password: !secret ota_password
-
 # native api of ESPHome
 #api:
 #  reboot_timeout: 60min

--- a/esphome/esphome_smarttherm.yaml
+++ b/esphome/esphome_smarttherm.yaml
@@ -20,7 +20,9 @@ ota:
 
 # native api of ESPHome
 #api:
-#  password: !secret api_password
+#  reboot_timeout: 60min
+#  encryption:
+#    key: !secret encryption_key
 
 # or mqtt (my choice)
  mqtt:

--- a/esphome/esphome_smarttherm.yaml
+++ b/esphome/esphome_smarttherm.yaml
@@ -54,24 +54,27 @@ output:
     id: pwm_output
 
 switch:
-  - platform: gpio
-    pin: D4
-    id: onboard_led
-    inverted: True
-    internal: True
-
   - platform: template
     name: ${unit_name}_heating
     id: heating
     entity_category: config
-    restore_state: True
+    restore_mode: RESTORE_DEFAULT_OFF
+    icon: "mdi:water-boiler"
     optimistic: True
     turn_on_action:
-      - switch.turn_on: onboard_led
+      - light.turn_on: onboard_led
       - script.execute: set_pwm_level_from_slider
     turn_off_action:
-      - switch.turn_off: onboard_led
+      - light.turn_off: onboard_led
       - script.execute: set_pwm_low_level
+
+light:
+  - platform: status_led
+    id: onboard_led
+    internal: True
+    pin:
+      number: D4
+      inverted: true
 
 script:
   - id: set_pwm_level_from_slider
@@ -106,6 +109,7 @@ number:
     mode: slider
     optimistic: True
     entity_category: config
+    icon: "mdi:gas-burner"
     on_value:
       then:
       - sensor.template.publish:
@@ -175,6 +179,7 @@ binary_sensor:
         pullup: True
     name: ${unit_name}_active
     id: power_active
+    device_class: power
     filters: # debounce
       - delayed_on: 5s
       - delayed_off: 5s


### PR DESCRIPTION
- change switch `restore_state` to `restore_mode` as the former configuration option is not supported anymore
- change onboard_led to be a `status_led` light platform, so it can be double purposed as both ESPHome Status LED and heating indicator
- add some entity icons, device class
- API password is not supported (deprecated) it needs encryption only